### PR TITLE
Get rid of deprecation warning

### DIFF
--- a/lib/responders.rb
+++ b/lib/responders.rb
@@ -9,7 +9,11 @@ module Responders
 
   class Railtie < ::Rails::Railtie
     config.responders = ActiveSupport::OrderedOptions.new
-    config.generators.scaffold_controller = :responders_controller
+    if config.respond_to?(:app_generators)
+      config.app_generators.scaffold_controller = :responders_controller
+    else
+      config.generators.scaffold_controller = :responders_controller
+    end
 
     # Add load paths straight to I18n, so engines and application can overwrite it.
     require 'active_support/i18n'


### PR DESCRIPTION
Hi,

I changed `responder.rb` to get rid of deprecation warning that is printed when I use this gem on the edge Rails.

`config.generators` in Rails::Railtie is deprecated.
