### PR TITLE
Use proper resource if there was used array of respond_with params for ne

### DIFF
--- a/lib/responders/flash_responder.rb
+++ b/lib/responders/flash_responder.rb
@@ -132,6 +132,7 @@ module Responders
     end
 
     def mount_i18n_options(status) #:nodoc:
+      resource = resource.last if resource.is_a?(Array)
       resource_name = if resource.class.respond_to?(:model_name)
         resource.class.model_name.human
       else


### PR DESCRIPTION
Use proper resource if there was used array of respond_with params for nested resources. 

``` ruby
respond_with([@project, @task])
```

will produce "Array was successfully created."
