### PR TITLE
HttpCacheResponder returns 304 even when the collection has different set of resources

### DIFF
--- a/lib/responders/http_cache_responder.rb
+++ b/lib/responders/http_cache_responder.rb
@@ -22,9 +22,7 @@ module Responders
   protected
 
     def do_http_cache!
-      timestamp = resources.flatten.map do |resource|
-        resource.updated_at.try(:utc) if resource.respond_to?(:updated_at)
-      end.compact.max
+      timestamp = resource.updated_at.try(:utc) if resource.respond_to?(:updated_at)
 
       controller.response.last_modified ||= timestamp if timestamp
 

--- a/test/http_cache_responder_test.rb
+++ b/test/http_cache_responder_test.rb
@@ -86,10 +86,11 @@ class HttpCacheResponderTest < ActionController::TestCase
     assert_equal 200, @response.status
   end
 
-  def test_collection_chooses_the_latest_timestamp
+  def test_does_not_set_cache_for_collection
     get :collection
-    assert_equal Time.utc(2009).httpdate, @response.headers["Last-Modified"]
-    assert_match /xml/, @response.body
+
+    assert_nil @response.headers["Last-Modified"]
+    assert_not_nil @response.headers["ETag"]
     assert_equal 200, @response.status
   end
 
@@ -113,8 +114,8 @@ class HttpCacheResponderTest < ActionController::TestCase
     assert_equal 200, @response.status
   end
 
-  def test_it_does_not_set_body_etag
-    get :collection
+  def test_it_does_not_set_body_etag_for_single_resource
+    get :single
     assert_nil @response.headers["ETag"]
   end
 


### PR DESCRIPTION
Added a test to expose the issue with http cache responder returning 304 even when collection has changed.

I don't have a fix for this bug and I do not see a way to determine how to decide whether to return 304 or 200 based on just the Last-Modified header. 

This Last-Modified header based caching strategy may not be possible for collection of resources and it should fallback to etag generated by rails.
