### PR TITLE
Fixed JRuby issue with implicit symbol conversion

### DIFF
--- a/lib/responders/flash_responder.rb
+++ b/lib/responders/flash_responder.rb
@@ -166,7 +166,7 @@ module Responders
 
       while slices.size > 0
         controller_scope = :"flash.#{slices.fill(controller.controller_name, -1).join('.')}.#{controller.action_name}.#{status}"
-        actions_scope = :"flash.#{slices.fill(:actions, -1).join('.')}.#{controller.action_name}.#{status}"
+        actions_scope = :"flash.#{slices.fill('actions', -1).join('.')}.#{controller.action_name}.#{status}"
 
         defaults << :"#{controller_scope}_html"
         defaults << controller_scope


### PR DESCRIPTION
JRuby was failing with an implicit conversion from Symbol to String in flash_responders.rb line 169.

I've fixed the issue and checked all tests still pass under MRI.
