### PR TITLE
Camelize instead of classify

### DIFF
--- a/lib/responders/controller_method.rb
+++ b/lib/responders/controller_method.rb
@@ -22,7 +22,7 @@ module Responders
           when Module
             responder
           when String, Symbol
-            Responders.const_get("#{responder.to_s.classify}Responder")
+            Responders.const_get("#{responder.to_s.camelize}Responder")
           else
             raise "responder has to be a string, a symbol or a module"
           end

--- a/test/controller_method_test.rb
+++ b/test/controller_method_test.rb
@@ -16,7 +16,7 @@ module BarResponder
   end
 end
 
-module BazResponder
+module PeopleResponder
   def to_html
     @resource << "baz"
     super
@@ -35,7 +35,7 @@ class PeopleController < ApplicationController
 end
 
 class SpecialPeopleController < PeopleController
-  responders :baz
+  responders :people
 end
 
 class ControllerMethodTest < ActionController::TestCase


### PR DESCRIPTION
Took me a second or three to understand why `responders :empty_js` was not finding `EmptyJResponder`.
