### PR TITLE
Default flash message on create with errors

### DIFF
--- a/lib/responders/locales/en.yml
+++ b/lib/responders/locales/en.yml
@@ -3,6 +3,7 @@ en:
     actions:
       create:
         notice: '%{resource_name} was successfully created.'
+        alert: '%{resource_name} could not be created.'
       update:
         notice: '%{resource_name} was successfully updated.'
       destroy:


### PR DESCRIPTION
It took me and at least one other person some time to figure out why there are no flash messages displayed on create with errors: https://github.com/josevalim/inherited_resources/issues/217

Probably it's best to add it into the generator.
