### PR TITLE
ensure that collection responder works with uncountable mode name

### DIFF
--- a/test/collection_responder_test.rb
+++ b/test/collection_responder_test.rb
@@ -30,6 +30,10 @@ class CollectionController < ApplicationController
   def isolated_namespace
     respond_with MyEngine::Business.new
   end
+
+  def uncountable
+    respond_with News.new
+  end
 end
 
 class CollectionResponderTest < ActionController::TestCase
@@ -68,5 +72,11 @@ class CollectionResponderTest < ActionController::TestCase
     @controller.expects(:businesses_url).returns("businesses_url")
     post :isolated_namespace
     assert_redirected_to "businesses_url"
+  end
+
+  def test_collection_respects_uncountable_resource
+    @controller.expects(:news_index_url).returns("news_index_url")
+    post :uncountable
+    assert_redirected_to "news_index_url"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,7 @@ I18n.reload!
 
 Responders::Routes = ActionDispatch::Routing::RouteSet.new
 Responders::Routes.draw do
+  resources :news
   match '/admin/:action', :controller => "admin/addresses"
   match '/:controller(/:action(/:id))'
 end
@@ -63,6 +64,9 @@ class Address < Model
 end
 
 class User < Model
+end
+
+class News < Model
 end
 
 module MyEngine


### PR DESCRIPTION
add spec to ensure that collection responder works with uncountable mode name

related to #54
