### PR TITLE
Add license to gemspec

### DIFF
--- a/responders.gemspec
+++ b/responders.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/plataformatec/responders"
   s.description = "A set of Rails responders to dry up your application"
   s.authors     = ['José Valim']
+  s.license     = "MIT"
 
   s.rubyforge_project = "responders"
 


### PR DESCRIPTION
Prior to this commit, the gemspec did not include the license, which
means that one can't use the rubygems API to automatically determine
licensing of vendored gems. This commit adds the licensing to the
gemspec.
