### PR TITLE
Add refactoring in the controller generator

### DIFF
--- a/lib/generators/rails/responders_controller_generator.rb
+++ b/lib/generators/rails/responders_controller_generator.rb
@@ -24,7 +24,7 @@ module Rails
       end
 
       def controller_before_filter
-        if defined?(ApplicationController) && ApplicationController.respond_to?(:before_action)
+        if ActionController::Base.respond_to?(:before_action)
           "before_action"
         else
           "before_filter"


### PR DESCRIPTION
Call `respond_to?(:before_action)` to `ActionController::Base` instead of
call it to `ApplicationController` avoiding ask to ApplicationController
if it is defined.

Kudos to @lucasmazza
