### PR TITLE
fix translation-missing in rails 4

### DIFF
--- a/lib/responders/flash_responder.rb
+++ b/lib/responders/flash_responder.rb
@@ -89,7 +89,10 @@ module Responders
 
     self.flash_keys = [ :notice, :alert ]
     self.namespace_lookup = false
-    self.helper = Object.new.extend(ActionView::Helpers::TranslationHelper)
+    self.helper = Object.new.extend(
+      ActionView::Helpers::TranslationHelper,
+      ActionView::Helpers::TagHelper
+    )
 
     def initialize(controller, resources, options={})
       super


### PR DESCRIPTION
In Rails 4, when the TranslationHelper#t fails to find a translation, it tries to render a `span.translation_missing` using the `content_tag` helper.

see: https://github.com/rails/rails/blob/c0fb8d0b9c4d55770f7ce1a9cb62e4f2a75ca3ee/actionview/lib/action_view/helpers/translation_helper.rb#L65
(introduced in https://github.com/rails/rails/commit/0c7ac34aed1845044cd1911e5a775366d7ca41c1)
