### PR TITLE
Remove 'resourceful?' check.

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -187,8 +187,8 @@ module ActionController #:nodoc:
       else
         display_errors
       end
-    rescue ActionView::MissingTemplate => e
-      api_behavior(e)
+    rescue ActionView::MissingTemplate
+      api_behavior
     end
 
   protected
@@ -205,8 +205,7 @@ module ActionController #:nodoc:
     end
 
     # This is the common behavior for formats associated with APIs, such as :xml and :json.
-    def api_behavior(error)
-      raise error unless resourceful?
+    def api_behavior
       raise MissingRenderer.new(format) unless has_renderer?
 
       if get?
@@ -216,12 +215,6 @@ module ActionController #:nodoc:
       else
         head :no_content
       end
-    end
-
-    # Checks whether the resource responds to the current format or not.
-    #
-    def resourceful?
-      resource.respond_to?("to_#{format}")
     end
 
     # Returns the resource location by retrieving it from the options or

--- a/lib/responders/http_cache_responder.rb
+++ b/lib/responders/http_cache_responder.rb
@@ -34,7 +34,7 @@ module Responders
 
     def do_http_cache?
       get? && @http_cache != false && ActionController::Base.perform_caching &&
-        persisted? && resourceful? && resource.respond_to?(:updated_at)
+        persisted? && resource.respond_to?(:updated_at)
     end
 
     def persisted?

--- a/test/action_controller/respond_with_test.rb
+++ b/test/action_controller/respond_with_test.rb
@@ -4,8 +4,6 @@ class Customer < Struct.new(:name, :id)
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 
-  undef_method :to_json
-
   def to_xml(options={})
     if options[:builder]
       options[:builder].name name
@@ -201,9 +199,9 @@ class RespondWithControllerTest < ActionController::TestCase
     assert_equal "<name>david</name>", @response.body
 
     @request.accept = "application/json"
-    assert_raise ActionView::MissingTemplate do
-      get :using_resource
-    end
+    get :using_resource
+    assert_equal "application/json", @response.content_type
+    assert_equal "{\"name\":\"david\",\"id\":13}", @response.body
   end
 
   def test_using_resource_with_js_simply_tries_to_render_the_template


### PR DESCRIPTION
This method requires that all resources should implement a 'to_#{format}' API
when this is actually responsability of the renderer that Rails will use for
the response format. This is particually annoying when implementing a new format
that is based in an existing serialization protocol like using a ':hal' format
while using 'to_json' to serialize the resources.

/cc @josevalim 
