### PR TITLE
Make dependency on action_controller explicit

### DIFF
--- a/lib/responders.rb
+++ b/lib/responders.rb
@@ -1,4 +1,4 @@
-require 'action_controller/base'
+require 'action_controller'
 
 module ActionController
   autoload :Responder, 'action_controller/responder'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ require 'mocha/setup'
 ENV["RAILS_ENV"] = "test"
 
 require 'active_support'
-require 'action_controller'
 require 'active_model'
 require 'rails/engine'
 require 'rails/railtie'


### PR DESCRIPTION
The `responders.rb` file requires the whole of `action_controller`, not just `action_controller/base` (which can't be loaded on its own). Requiring only `action_controller/base` causes dependency errors in projects that don't explicitly require `action_controller` elsewhere.

Once `action_controller` is required in `responders.rb` it can be removed from `test_helper.rb`.
