### PR TITLE
Use singular and plural table name to generate properly namespaced controllers

### DIFF
--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -1,55 +1,55 @@
 <% module_namespacing do -%>
 class <%= controller_class_name %>Controller < ApplicationController
-  <%= controller_before_filter %> :set_<%= file_name %>, only: [:show, :edit, :update, :destroy]
+  <%= controller_before_filter %> :set_<%= singular_table_name %>, only: [:show, :edit, :update, :destroy]
 
   respond_to :html
 
 <% unless options[:singleton] -%>
   def index
-    @<%= table_name %> = <%= orm_class.all(class_name) %>
-    respond_with(@<%= table_name %>)
+    @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
+    respond_with(@<%= plural_table_name %>)
   end
 <% end -%>
 
   def show
-    respond_with(@<%= file_name %>)
+    respond_with(@<%= singular_table_name %>)
   end
 
   def new
-    @<%= file_name %> = <%= orm_class.build(class_name) %>
-    respond_with(@<%= file_name %>)
+    @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
+    respond_with(@<%= singular_table_name %>)
   end
 
   def edit
   end
 
   def create
-    @<%= file_name %> = <%= orm_class.build(class_name, attributes_params) %>
+    @<%= singular_table_name %> = <%= orm_class.build(class_name, attributes_params) %>
     <%= "flash[:notice] = '#{class_name} was successfully created.' if " if flash? %>@<%= orm_instance.save %>
-    respond_with(@<%= file_name %>)
+    respond_with(@<%= singular_table_name %>)
   end
 
   def update
     <%= "flash[:notice] = '#{class_name} was successfully updated.' if " if flash? %>@<%= orm_instance_update(attributes_params) %>
-    respond_with(@<%= file_name %>)
+    respond_with(@<%= singular_table_name %>)
   end
 
   def destroy
     @<%= orm_instance.destroy %>
-    respond_with(@<%= file_name %>)
+    respond_with(@<%= singular_table_name %>)
   end
 
   private
-    def set_<%= file_name %>
-      @<%= file_name %> = <%= orm_class.find(class_name, "params[:id]") %>
+    def set_<%= singular_table_name %>
+      @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
     end
     <%- if strong_parameters_defined? -%>
 
-    def <%= "#{file_name}_params" %>
+    def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params[:<%= file_name %>]
+      params[:<%= singular_table_name %>]
       <%- else -%>
-      params.require(:<%= file_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
       <%- end -%>
     end
     <%- end -%>


### PR DESCRIPTION
The controller that was generated when creating a namespaced resource was: 

``` ruby
class Client::OrdersController < ApplicationController
  before_action :set_order, only: [:show, :edit, :update, :destroy]

  def index
    @client_orders = Client::Order.all
    respond_with(@client_orders)
  end

  def show
    respond_with(@order)
  end

  def new
    @order = Client::Order.new
    respond_with(@order)
  end

  def edit
  end

  def create
    @order = Client::Order.new(order_params)
    @client_order.save
    respond_with(@order)
  end

  def update
    @client_order.update(order_params)
    respond_with(@order)
  end

  def destroy
    @client_order.destroy
    respond_with(@order)
  end

  private
    def set_order
      @order = Client::Order.find(params[:id])
    end

    def order_params
      params.require(:order).permit(:title)
    end
end
```

This change will create a proper controller such as this one:

``` ruby
class Client::OrdersController < ApplicationController
  before_action :set_client_order, only: [:show, :edit, :update, :destroy]

  def index
    @client_orders = Client::Order.all
    respond_with(@client_orders)
  end

  def show
    respond_with(@client_order)
  end

  def new
    @client_order = Client::Order.new
    respond_with(@client_order)
  end

  def edit
  end

  def create
    @client_order = Client::Order.new(order_params)
    @client_order.save
    respond_with(@client_order)
  end

  def update
    @client_order.update(order_params)
    respond_with(@client_order)
  end

  def destroy
    @client_order.destroy
    respond_with(@client_order)
  end

  private
    def set_client_order
      @client_order = Client::Order.find(params[:id])
    end

    def client_order_params
      params.require(:client_order).permit(:title)
    end
end
```
