### PR TITLE
Respond with the resource even for PUT, PATCH and DELETE

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -208,12 +208,10 @@ module ActionController #:nodoc:
     def api_behavior
       raise MissingRenderer.new(format) unless has_renderer?
 
-      if get?
-        display resource
-      elsif post?
+      if post?
         display resource, :status => :created, :location => api_location
       else
-        head :no_content
+        display resource
       end
     end
 


### PR DESCRIPTION
In reference of that [website](http://www.restapitutorial.com/lessons/httpmethods.html) and this [image](http://i.stack.imgur.com/whhD1.png) I understand than, in the conventions of REST, the result of a succesful PUT should be empty, but I think it's not the Rails way. 

After a PUT, `created_at` and `updated_at` can be changed and it can be useful to return them. If we use the standard routes, `POST /users/1.json` will be refused and, with responders, `PUT /users/1.json` will be refused so we don't have a way to have a return after a PUT. 

Furthermore, there is [some users with problems](http://stackoverflow.com/questions/9953887/simple-respond-with-in-rails-that-avoids-204-from-put) and I have the same.

What you think? Is it better to have custom routes or to fix Responders?

Thanks!