### PR TITLE
Lazy load ActionController

### DIFF
--- a/lib/responders/controller_method.rb
+++ b/lib/responders/controller_method.rb
@@ -34,4 +34,6 @@ module Responders
   end
 end
 
-ActionController::Base.extend Responders::ControllerMethod
+ActiveSupport.on_load(:action_controller) do
+  ActionController::Base.extend Responders::ControllerMethod
+end


### PR DESCRIPTION
In a Rails application using responders, we cannot set
`config.action_controller` configurations in the initializers phase,
because responders loads ActionController too early. This patch fixes
the problem by moving codes into lazy load hook.