### PR TITLE
use unshift for load path

### DIFF
--- a/responders.gemspec
+++ b/responders.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+$:.unshift File.expand_path("../lib", __FILE__)
 require "responders/version"
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
when an older version is already installed, generated gemspec file gets wrong version (noticed in debian package)