### PR TITLE
Fix a JSON rendering of the Rails 5 API

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -182,7 +182,9 @@ module ActionController #:nodoc:
     # responds to :to_format and display it.
     #
     def to_format
-      if get? || !has_errors? || response_overridden?
+      if ActionPack::VERSION::MAJOR >= 5 && controller.is_a?(ActionController::API)
+        api_behavior
+      elsif get? || !has_errors? || response_overridden?
         default_render
       else
         display_errors


### PR DESCRIPTION
A JSON rendering doesn't work when using the Rails 5 API...

## simple test case

```ruby
class ApplicationController < ActionController::API
end

class PostsController < ApplicationController
  respond_to :json

  def index
    @posts = Post.all
    respond_with @posts
  end
end
```