### PR TITLE
Add the `verify_request_format!` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## HEAD
+
+* Added the `verify_request_format!` method, that can be used as a `before_action`
+  callback to prevent your actions from being invoked when the controller does
+  not respond to the request mime type, preventing the execution of complex
+  queries or creating/deleting records from your app.
+
 ## 2.1.2
 
 * Fix rendering when using `ActionController::API`. (by @eLod)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Update your bundle and run the install generator:
     $ bundle install
     $ rails g responders:install
 
-If you are including this gem to support backwards compatibilty for responders in previous releases of Rails, you only need to include the gem and bundle. 
+If you are including this gem to support backwards compatibilty for responders in previous releases of Rails, you only need to include the gem and bundle.
 
     $ bundle install
 
@@ -188,7 +188,7 @@ to use `respond_with` instead of default `respond_to` blocks. From 2.1, you need
 
     config.app_generators.scaffold_controller :responders_controller
 
-#Failure handling
+## Failure handling
 
 Responders don't use `valid?` to check for errors in models to figure out if
 the request was successfull or not, and relies on your controllers to call
@@ -214,6 +214,29 @@ def create
   # `respond_with` will render the `new` template again.
   respond_with @widget
 end
+```
+
+## Verifying request formats
+
+`respond_with` will raise an `ActionController::UnknownFormat` if the request
+mime type was not configured through the class level `respond_to`, but the
+action will still be executed and any side effects (like creating a new record)
+will still occur. To raise the `UnknownFormat` exception before your action
+is invoked you can set the `verify_request_format!` method as a `before_action`
+on your controller.
+
+```ruby
+class WidgetsController < ApplicationController
+  respond_to :json
+  before_action :verify_request_format!
+
+  # POST /widgets.html won't reach the `create` action.
+  def create
+    widget = Widget.create(widget_params)
+    respond_with widget
+  end
+end
+
 ```
 
 ## Examples

--- a/test/action_controller/verify_request_format_test.rb
+++ b/test/action_controller/verify_request_format_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class ThingsController < ApplicationController
+  clear_respond_to
+
+  respond_to :js
+  respond_to :html, :only => [:show, :new]
+
+  before_action :verify_request_format!
+
+  attr_reader :called
+
+  def action
+    @called = true
+    render :inline => action_name
+  end
+
+  alias :index :action
+  alias :show :action
+  alias :new :action
+end
+
+class VerifyRequestFormatTest < ActionController::TestCase
+  tests ThingsController
+
+  def test_strict_mode_shouldnt_call_action
+    assert_raises(ActionController::UnknownFormat) do
+      get :index
+    end
+
+    refute @controller.called, 'action should not be executed.'
+  end
+
+  def test_strict_mode_calls_action_with_right_format
+    get :index, :format => :js
+
+    assert @controller.called, 'action should be executed.'
+  end
+
+  def test_strict_mode_respects_only_option
+    get :show, :format => :html
+
+    assert @controller.called, 'action should be executed.'
+  end
+end


### PR DESCRIPTION
You can use `verify_request_format!` as a `before_action` callback to valida
the request mime type before the action is invoked, and prevent any extra wo
if the request format isn't configured for the current action.

Closes #143.