### PR TITLE
Add Rails 5 API controller template for the controller generator

### DIFF
--- a/lib/generators/rails/templates/api_controller.rb
+++ b/lib/generators/rails/templates/api_controller.rb
@@ -1,0 +1,51 @@
+<% if namespaced? -%>
+require_dependency "<%= namespaced_file_path %>/application_controller"
+
+<% end -%>
+<% module_namespacing do -%>
+class <%= controller_class_name %>Controller < ApplicationController
+  before_action :set_<%= singular_table_name %>, only: [:show, :update, :destroy]
+
+  respond_to :json
+
+<% unless options[:singleton] -%>
+  def index
+    @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
+    respond_with(@<%= plural_table_name %>)
+  end
+<% end -%>
+
+  def show
+    respond_with(@<%= singular_table_name %>)
+  end
+
+  def create
+    @<%= singular_table_name %> = <%= orm_class.build(class_name, attributes_params) %>
+    <%= "flash[:notice] = '#{class_name} was successfully created.' if " if flash? %>@<%= orm_instance.save %>
+    respond_with(@<%= singular_table_name %>)
+  end
+
+  def update
+    <%= "flash[:notice] = '#{class_name} was successfully updated.' if " if flash? %>@<%= orm_instance.update(attributes_params) %>
+    respond_with(@<%= singular_table_name %>)
+  end
+
+  def destroy
+    @<%= orm_instance.destroy %>
+    respond_with(@<%= singular_table_name %>)
+  end
+
+  private
+    def set_<%= singular_table_name %>
+      @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
+    end
+
+    def <%= "#{singular_table_name}_params" %>
+      <%- if attributes_names.empty? -%>
+      params[:<%= singular_table_name %>]
+      <%- else -%>
+      params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      <%- end -%>
+    end
+end
+<% end -%>


### PR DESCRIPTION
I've decided to try Rails 5 with a new API-only application. 

During my tests I've found that the current controller generator stumbles with the following error:

```
Could not find "api_controller.rb" in any of your source paths. Your current source paths are:
/Users/vestimir/.gem/ruby/2.3.0/gems/responders-2.1.0/lib/generators/rails/templates
```

So I've added a new template file for API controllers to fix this. By default it renders JSON and skips new and edit actions. 

**The problem**

Whenever I curl the resource I get an empty response, but if I put `render json: @posts`, instead of `respond_with(@posts)` I get proper JSON response. 

Could this be caused by some missing view-related middleware, any clues where to search in the codebase about this? 