### PR TITLE
Fix rendering in Rails 5 API controllers.

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -182,10 +182,12 @@ module ActionController #:nodoc:
     # responds to :to_format and display it.
     #
     def to_format
-      if get? || !has_errors? || response_overridden?
+      if !get? && has_errors? && !response_overridden?
+        display_errors
+      elsif has_view_rendering? || response_overridden?
         default_render
       else
-        display_errors
+        api_behavior
       end
     rescue ActionView::MissingTemplate
       api_behavior
@@ -271,6 +273,10 @@ module ActionController #:nodoc:
     # Check whether the necessary Renderer is available
     def has_renderer?
       Renderers::RENDERERS.include?(format)
+    end
+
+    def has_view_rendering?
+      controller.class.include? ActionView::Rendering
     end
 
     # By default, render the <code>:edit</code> action for HTML requests with errors, unless


### PR DESCRIPTION
Based on #146.

@lucasmazza: i thought it's better to check for `ActionView::Rendering` than for `ActionController::API`, because someone can use API and include the view rendering still. The current logic is depending on the view layer raising a template not found exception (so then it knows to switch to api behavior), so i thought it would be more consistent to handle it similarly when the view layer is not present. Not sure if it makes sense to use API with view rendering readded though, so i'm happy to refactor the code.