### PR TITLE
Improve `interpolation_options` integration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * `verify_request_format!` is aliased to `verify_requested_format!` now.
+* Implementing the `interpolation_options` method on your controller is deprecated
+  in favor of naming it `flash_interpolation_options` instead.
 
 ## 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ end
 
 ## Interpolation Options
 
-You can pass in extra interpolation options for the translation by adding an `interpolation_options` method to your controller:
+You can pass in extra interpolation options for the translation by adding an `flash_interpolation_options` method to your controller:
 
 ```ruby
 class InvitationsController < ApplicationController
@@ -173,7 +173,7 @@ class InvitationsController < ApplicationController
 
   private
 
-  def interpolation_options
+  def flash_interpolation_options
     { resource_name: @invitation.email }
   end
 end

--- a/lib/responders/flash_responder.rb
+++ b/lib/responders/flash_responder.rb
@@ -33,9 +33,9 @@ module Responders
   #         notice: "Hooray! You just tuned your %{car_brand}!"
   #
   # Since :car_name is not available for interpolation by default, you have
-  # to overwrite interpolation_options in your controller.
+  # to overwrite `flash_interpolation_options` in your controller.
   #
-  #   def interpolation_options
+  #   def flash_interpolation_options
   #     { :car_brand => @car.brand }
   #   end
   #
@@ -153,11 +153,21 @@ module Responders
         :downcase_resource_name => resource_name.downcase
       }
 
-      if controller.respond_to?(:interpolation_options, true)
-        options.merge!(controller.send(:interpolation_options))
+      controller_options = controller_interpolation_options
+      if controller_options
+        options.merge!(controller_options)
       end
 
       options
+    end
+
+    def controller_interpolation_options
+      if controller.respond_to?(:flash_interpolation_options, true)
+        controller.send(:flash_interpolation_options)
+      elsif controller.respond_to?(:interpolation_options, true)
+        ActiveSupport::Deprecation.warn("[responders] `#{controller.class}#interpolation_options` is deprecated, please rename it to `flash_interpolation_options`.")
+        controller.send(:interpolation_options)
+      end
     end
 
     def resource_name

--- a/test/responders/flash_responder_test.rb
+++ b/test/responders/flash_responder_test.rb
@@ -62,7 +62,7 @@ class AddressesController < ApplicationController
 
   protected
 
-  def interpolation_options
+  def flash_interpolation_options
     { :reference => 'Ocean Avenue', :xss => '<script>alert(1)</script>' }
   end
 


### PR DESCRIPTION
1. Add support for a more specific controller method, `flash_interpolation_options`,
   which can be more intention revealing for developers reading the controller
   implementation without having prior knowledge of the Responders API.
2. Avoid merging `nil` onto the existing options Hash, so the controller implementation
   doesn't need to worry about returning empty hashes when it can create the
   interpolation options (for instance, when the method is called for an `index`
   action when you only want ot pass interpolation options to resource specific
   actions).