### PR TITLE
Try for a response format that has an available renderer.

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -129,7 +129,8 @@ module ActionController #:nodoc:
     def initialize(controller, resources, options={})
       @controller = controller
       @request = @controller.request
-      @format = @controller.formats.first
+      
+      @format = @controller.formats.detect{|f| Renderers::RENDERERS.include?(f) } || @controller.formats.first
       @resource = resources.last
       @resources = resources
       @options = options

--- a/test/action_controller/respond_with_api_test.rb
+++ b/test/action_controller/respond_with_api_test.rb
@@ -40,5 +40,15 @@ if defined?(ActionController::API)
       expected = { errors: errors }
       assert_equal expected.to_json, @response.body
     end
+
+    def test_uses_backup_render_if_request_comes_in_with_multiple_accepts
+      @request.headers["ACCEPT"] = 'application/x-mpac,application/json; q=0.5'
+      get :index
+
+      assert_equal "application/json", @response.content_type
+      assert_equal 200, @response.status
+      expected = [{ name: 'Foo', id: 1 }, { name: 'Bar', id: 2 }]
+      assert_equal expected.to_json, @response.body
+    end
   end
 end

--- a/test/action_controller/respond_with_test.rb
+++ b/test/action_controller/respond_with_test.rb
@@ -601,6 +601,16 @@ class RespondWithControllerTest < ActionController::TestCase
     end
   end
 
+  def test_uses_backup_render_if_request_comes_in_with_multiple_accepts
+    @controller = InheritedRespondWithController.new
+    @request.headers["ACCEPT"] = 'application/x-mpac,application/json; q=0.5' 
+    get :index
+
+    assert_equal "application/json", @response.content_type
+    assert_equal 200, @response.status
+    assert_equal "JSON", response.body
+  end
+
   def test_error_is_raised_if_no_respond_to_is_declared_and_respond_with_is_called
     @controller = EmptyRespondWithController.new
     @request.accept = "*/*"


### PR DESCRIPTION
Issue affected ActionController::API controllers when submitting a request with multiple accept types for which the preferred one may not have a renderer.
