### PR TITLE
Added a `default_error_status` option to allow custom status code on failure

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -135,6 +135,7 @@ module ActionController #:nodoc:
       @options = options
       @action = options.delete(:action)
       @default_response = options.delete(:default_response)
+      @default_error_status = options.delete(:default_error_status) || :ok
 
       if options[:location].respond_to?(:call)
         location = options.delete(:location)
@@ -200,7 +201,7 @@ module ActionController #:nodoc:
       if get?
         raise error
       elsif has_errors? && default_action
-        render :action => default_action
+        render action: default_action, status: @default_error_status
       else
         redirect_to navigation_location
       end

--- a/test/action_controller/respond_with_test.rb
+++ b/test/action_controller/respond_with_test.rb
@@ -66,6 +66,10 @@ class RespondWithController < ApplicationController
     end
   end
 
+  def using_resource_with_default_error_status
+    respond_with(resource, :default_error_status => :unprocessable_entity)
+  end
+
   def using_responder_with_respond
     responder = Class.new(ActionController::Responder) do
       def respond; @controller.render :body => "respond #{format}"; end
@@ -222,6 +226,16 @@ class RespondWithControllerTest < ActionController::TestCase
     @request.accept = "text/javascript"
     assert_raises(ActionController::UnknownFormat) do
       get :using_resource_with_overwrite_block
+    end
+  end
+
+  def test_using_default_error_status_yields_custom_status_on_failure
+    with_test_route_set do
+      errors = { :name => :invalid }
+      Customer.any_instance.stubs(:errors).returns(errors)
+      post :using_resource_with_default_error_status
+
+      assert_response :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
Hey guys thanks for maintaining this gem! We are trying to clean our controller using the responder gem with all the nice features it has, but we are stuck on the described behaviour below.
We heavily rely on the 422 status code when model contains validation errors, and a bunch of logic in our codebase surrounds it.
I hope this PR would make sense to you, thanks!

- JS and html request will re-render the view with a 200 status code in case the model contains validation errors
- This PR aims to customize this behaviour by allowing to pass a status code which will be used instead of the default one
- Fixes https://github.com/plataformatec/responders/issues/159

