### PR TITLE
Allow rendering a template outside of controller's path:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* `respond_with` now accepts a new kwargs called `:render` which goes straight to the `render`
+   call after an unsuccessful post request. Usefull if for example you need to render a template
+   which is outside of controller's path eg:
+
+   `respond_with resource, render: { template: 'path/to/template' }`
+
 ## 2.3.0
 
 * `verify_request_format!` is aliased to `verify_requested_format!` now.

--- a/lib/action_controller/respond_with.rb
+++ b/lib/action_controller/respond_with.rb
@@ -182,11 +182,17 @@ module ActionController #:nodoc:
     # to save a resource, e.g. when automatically rendering <tt>:new</tt>
     # after a post request.
     #
-    # Two additional options are relevant specifically to +respond_with+ -
+    # Three additional options are relevant specifically to +respond_with+ -
     # 1. <tt>:location</tt> - overwrites the default redirect location used after
     #    a successful html +post+ request.
     # 2. <tt>:action</tt> - overwrites the default render action used after an
     #    unsuccessful html +post+ request.
+    # 3. <tt>:render</tt> - allows to pass any options directly to the <tt>:render<tt/>
+    #    call after unsuccessful html +post+ request. Usefull if for example you
+    #    need to render a template which is outside of controller's path or you
+    #    want to override the default http <tt>:status</tt> code, e.g.
+    #
+    #    response_with(resource, render: { template: 'path/to/template', status: 422 })
     def respond_with(*resources, &block)
       if self.class.mimes_for_respond_to.empty?
         raise "In order to use respond_with, first you need to declare the " \

--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -200,7 +200,7 @@ module ActionController #:nodoc:
       if get?
         raise error
       elsif has_errors? && default_action
-        render :action => default_action
+        render rendering_options
       else
         redirect_to navigation_location
       end
@@ -296,6 +296,14 @@ module ActionController #:nodoc:
 
     def response_overridden?
       @default_response.present?
+    end
+
+    def rendering_options
+      if options[:render]
+        options[:render]
+      else
+        { action: default_action }
+      end
     end
   end
 end

--- a/test/action_controller/respond_with_test.rb
+++ b/test/action_controller/respond_with_test.rb
@@ -66,6 +66,13 @@ class RespondWithController < ApplicationController
     end
   end
 
+  def using_resource_with_rendering_options
+    rendering_options = { template: 'addresses/edit', status: :unprocessable_entity }
+    respond_with(resource, render: rendering_options) do |format|
+      format.html { raise ActionView::MissingTemplate.new([], "bar", ["foo"], {}, false) }
+    end
+  end
+
   def using_responder_with_respond
     responder = Class.new(ActionController::Responder) do
       def respond; @controller.render :body => "respond #{format}"; end
@@ -480,6 +487,15 @@ class RespondWithControllerTest < ActionController::TestCase
 
     post :using_resource_with_action
     assert_equal "foo - #{[:html].to_s}", @controller.response.body
+  end
+
+  def test_using_resource_with_rendering_options
+    Customer.any_instance.stubs(:errors).returns(name: :invalid)
+
+    post :using_resource_with_rendering_options
+
+    assert_response :unprocessable_entity
+    assert_equal 'edit.html.erb', @controller.response.body
   end
 
   def test_respond_as_responder_entry_point


### PR DESCRIPTION
Hey guys 👋 , thanks for maintaining the responders gem

- Rails allow to pass a string or a method directly to the `render` method, if it contains a `/` in it's name we consider that the full path needs to be render, otherwise it will fallback to a template matching the action's name https://github.com/rails/rails/blob/4-2-stable/actionview/lib/action_view/rendering.rb#L119-L122
- This PR delates that logic to rails by removing the explicit `action` when rendering a template

Fixes #162