### PR TITLE
Gemfile: Add Bundler ruby version hint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 cache: bundler
 language: ruby
+before_install:
+  - gem update --system
+  - gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby RUBY_VERSION
+
 gemspec
 
 gem 'activemodel'


### PR DESCRIPTION
In order to get around the build failures on 1.9.3 and 2.0 re: not having an old-enough Nokogiri, this commit adds ruby version as a metadata hint to be taken into account when finding a suitable gem.

(This change is done to make master build green again.)