### PR TITLE
Revert "Allow rails 6"

### DIFF
--- a/responders.gemspec
+++ b/responders.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.files         = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "railties", ">= 4.2.0", "< 7.0"
-  s.add_dependency "actionpack", ">= 4.2.0", "< 7.0"
+  s.add_dependency "railties", ">= 4.2.0", "< 6.0"
+  s.add_dependency "actionpack", ">= 4.2.0", "< 6.0"
 end


### PR DESCRIPTION
Reverts plataformatec/responders#197.

The current master code already allows `responders` to be installed for Rails 6 beta, so it's enough for now. We'll update it to officially support Rails 6 when it's stable and we're sure this Gem is ready to work with it.