### PR TITLE
`rubyforge_project` attribute was removed from rubygems

### DIFF
--- a/responders.gemspec
+++ b/responders.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.authors     = ["José Valim"]
   s.license     = "MIT"
 
-  s.rubyforge_project = "responders"
-
   s.files         = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
See https://github.com/rubygems/rubygems/pull/2436 and https://github.com/rubygems/rubygems/pull/2798.