### PR TITLE
Point Rails 6 Gemfile to 6-0-stable

### DIFF
--- a/gemfiles/Gemfile-rails.6.0.x
+++ b/gemfiles/Gemfile-rails.6.0.x
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'activemodel', github: 'rails/rails'
-gem 'railties', github: 'rails/rails'
+gem 'activemodel', github: 'rails/rails', branch: '6-0-stable'
+gem 'railties', github: 'rails/rails', branch: '6-0-stable'
 gem 'mocha'
 gem 'rails-controller-testing'
 gem 'rack', github: 'rack/rack'


### PR DESCRIPTION
Because master is now 6.1.0.alpha.