### PR TITLE
Allow Rails 6.1 prereleases

### DIFF
--- a/responders.gemspec
+++ b/responders.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.files         = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "railties", ">= 4.2.0", "< 6.1"
-  s.add_dependency "actionpack", ">= 4.2.0", "< 6.1"
+  s.add_dependency "railties", ">= 4.2.0"
+  s.add_dependency "actionpack", ">= 4.2.0"
 end

--- a/responders.gemspec
+++ b/responders.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.files         = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "railties", ">= 4.2.0", "< 6.0"
-  s.add_dependency "actionpack", ">= 4.2.0", "< 6.0"
+  s.add_dependency "railties", ">= 4.2.0", "< 6.1"
+  s.add_dependency "actionpack", ">= 4.2.0", "< 6.1"
 end


### PR DESCRIPTION
So that responders can be easily tested against current rails master (6.1.0.alpha), and it's easier to get early feedback and bug reports.

References https://github.com/plataformatec/responders/commit/6e28cb3db90f1e3edd31e951172e78302c6a2e64#commitcomment-34011176.