### PR TITLE
Import ActionController::MissingRenderer from Rails

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -131,6 +131,13 @@ module ActionController # :nodoc:
       put: :edit
     }
 
+    # See Responder#api_behavior
+    class MissingRenderer < LoadError
+      def initialize(format)
+        super "No renderer defined for format: #{format}"
+      end
+    end
+
     def initialize(controller, resources, options = {})
       @controller = controller
       @request = @controller.request

--- a/test/action_controller/respond_with_test.rb
+++ b/test/action_controller/respond_with_test.rb
@@ -723,7 +723,7 @@ class RespondWithControllerTest < ActionController::TestCase
 
   def test_raises_missing_renderer_if_an_api_behavior_with_no_renderer
     @controller = CsvRespondWithController.new
-    assert_raise ActionController::MissingRenderer do
+    assert_raise ActionController::Responder::MissingRenderer do
       get :index, format: "csv"
     end
   end


### PR DESCRIPTION
Happened upon this exception when patching this file in rails/rails#48327, the documentation references a method which was moved to this gem, and nothing else in Rails uses it internally.

I think we can move it here and deprecate it from Rails, which I've started working on in rails/rails#48328