### PR TITLE
Accept `allow_other_host` as redirect option with `location`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Support `allow_other_host` option in `respond_with`, forwarded to `redirect_to` (#255)
 * Ruby 4.0 support (no changes required)
 
 ## 3.2.0

--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -103,6 +103,11 @@ module ActionController # :nodoc:
   #
   #   respond_with(@project, location: root_path)
   #
+  # If the location is an external URL, pass <code>allow_other_host: true</code>
+  # to permit the redirect (this is forwarded to <code>redirect_to</code>):
+  #
+  #   respond_with(@project, location: "https://example.com/", allow_other_host: true)
+  #
   # To customize the failure scenario, you can pass a block to
   # <code>respond_with</code>:
   #
@@ -207,7 +212,7 @@ module ActionController # :nodoc:
       elsif has_errors? && default_action
         render error_rendering_options
       else
-        redirect_to navigation_location, status: redirect_status
+        redirect_to navigation_location, redirect_options
       end
     end
 
@@ -313,6 +318,12 @@ module ActionController # :nodoc:
       else
         { action: default_action, status: error_status }
       end
+    end
+
+    def redirect_options
+      redirect_options = { status: redirect_status }
+      redirect_options[:allow_other_host] = options[:allow_other_host] if options.key?(:allow_other_host)
+      redirect_options
     end
   end
 end

--- a/test/action_controller/respond_with_test.rb
+++ b/test/action_controller/respond_with_test.rb
@@ -61,6 +61,10 @@ class RespondWithController < ApplicationController
     respond_with(@customer, status: 123, location: "http://test.host/")
   end
 
+  def using_resource_with_allow_other_host
+    respond_with(resource, location: "http://example.com/", allow_other_host: true)
+  end
+
   def using_resource_with_responder
     responder = proc { |c, r, o| c.render body: "Resource name is #{r.first.name}" }
     respond_with(resource, responder: responder)
@@ -751,6 +755,15 @@ class RespondWithControllerTest < ActionController::TestCase
         patch :using_resource
         assert_equal 301, @response.status
       end
+    end
+  end
+
+  def test_using_resource_with_allow_other_host
+    with_test_route_set do
+      post :using_resource_with_allow_other_host
+      assert_equal 302, @response.status
+      assert_equal "http://example.com/", @response.location
+      assert @response.redirect?
     end
   end
 


### PR DESCRIPTION
When `respond_with` + `location` needs to redirect to an external source, it may be necessary to pass `allow_other_host: true` to allow Rails to perform the redirect, otherwise it will be blocked.

Closes #237