### PR TITLE
Use public renderer API when available

### DIFF
--- a/lib/action_controller/responder.rb
+++ b/lib/action_controller/responder.rb
@@ -286,7 +286,8 @@ module ActionController # :nodoc:
 
     # Check whether the necessary Renderer is available
     def has_renderer?
-      Renderers::RENDERERS.include?(format)
+      renderers = Renderers.respond_to?(:all) ? Renderers.all : Renderers::RENDERERS
+      renderers.include?(format)
     end
 
     def has_view_rendering?


### PR DESCRIPTION
Rails deprecated `ActionController::Renderers::RENDERERS` in favour of `Renderers.all`. Prefer the public API when available while preserving compatibility with older supported Rails versions.

Originating Rails change: https://github.com/rails/rails/pull/57830